### PR TITLE
Add snack extension for SwiftUI

### DIFF
--- a/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Extensions/View+Extensions.swift
+++ b/ios/PresentationLayer/UIToolkit/Sources/UIToolkit/Extensions/View+Extensions.swift
@@ -38,7 +38,7 @@ public extension View {
     }
     
     func snack(
-            _ snackState: SnackState<InfoErrorSnackVisuals>
+        _ snackState: SnackState<InfoErrorSnackVisuals>
     ) -> some View {
         self
             .overlay(


### PR DESCRIPTION
Add SwiftUI view extension for default snack bar.
https://www.notion.so/mateedevs/Template-repository-Add-default-snack-extension-for-SwiftUI-6e436256054043a1a1c2e668f47aa3aa?pvs=4