### PR TITLE
🧑‍💻 [iOS] Create generic view controller for compose multiplatform screens

### DIFF
--- a/ios/PresentationLayer/SampleComposeMultiplatform/Sources/SampleComposeMultiplatform/ComposeViewController.swift
+++ b/ios/PresentationLayer/SampleComposeMultiplatform/Sources/SampleComposeMultiplatform/ComposeViewController.swift
@@ -1,0 +1,22 @@
+//
+//  Created by Julia Jakubcova on 25/09/2024
+//  Copyright © 2024 Matee. All rights reserved.
+//
+
+import KMPShared
+import SwiftUI
+
+struct ComposeViewController: UIViewControllerRepresentable {
+    private let makeScreenViewController: () -> UIViewController
+    
+    init(makeScreenViewController: @escaping () -> UIViewController) {
+        self.makeScreenViewController = makeScreenViewController
+    }
+    
+    func makeUIViewController(context: Context) -> UIViewController {
+        return makeScreenViewController()
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
+}

--- a/ios/PresentationLayer/SampleComposeMultiplatform/Sources/SampleComposeMultiplatform/SampleComposeMultiplatformView.swift
+++ b/ios/PresentationLayer/SampleComposeMultiplatform/Sources/SampleComposeMultiplatform/SampleComposeMultiplatformView.swift
@@ -9,27 +9,6 @@ import KMPShared
 import SwiftUI
 import UIToolkit
 
-struct SampleComposeMultiplatformViewController: UIViewControllerRepresentable {
-    
-    private var viewModel: KMPShared.SampleSharedViewModel
-    private let onEvent: (SampleSharedEvent) -> Void
-    
-    init(viewModel: KMPShared.SampleSharedViewModel, onEvent: @escaping (SampleSharedEvent) -> Void) {
-        self.viewModel = viewModel
-        self.onEvent = onEvent
-    }
-    
-    func makeUIViewController(context: Context) -> UIViewController {
-        return SampleComposeMultiplatformScreenViewControllerKt.SampleComposeMultiplatformScreenViewController(
-            viewModel: viewModel,
-            onEvent: onEvent
-        )
-    }
-    
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
-    }
-}
-
 struct SampleComposeMultiplatformView: View {
     
     @Injected(\.sampleSharedViewModel) private(set) var viewModel: KMPShared.SampleSharedViewModel
@@ -42,16 +21,18 @@ struct SampleComposeMultiplatformView: View {
     }
     
     var body: some View {
-        SampleComposeMultiplatformViewController(
-            viewModel: viewModel,
-            onEvent: { event in
-                switch event {
-                case let event as SampleSharedEventShowMessage:
-                    toastData = ToastData(event.message, hideAfter: 2)
-                default: print("Event \(event) not recognized")
+        ComposeViewController {
+            SampleComposeMultiplatformScreenViewControllerKt.SampleComposeMultiplatformScreenViewController(
+                viewModel: viewModel,
+                onEvent: { event in
+                    switch event {
+                    case let event as SampleSharedEventShowMessage:
+                        toastData = ToastData(event.message, hideAfter: 2)
+                    default: print("Event \(event) not recognized")
+                    }
                 }
-            }
-        )
+            )
+        }
         .toastView($toastData)
         .navigationTitle(L10n.bottom_bar_item_3)
     }


### PR DESCRIPTION
# :pencil: Description
- Create generic view controller for compose multiplatform screens

# :bulb: What’s new?
- ComposeViewController that can be used in SwiftUI views that call compose multiplatform code

# :no_mouth: What’s missing?
- Nothing

# :books: References
- [notion task](https://www.notion.so/mateedevs/Template-repository-Generic-wrapper-for-iOS-Compose-Multiplatform-views-ce1a5c9eb91c4de8b570879f2fc62d28?pvs=4)
