### PR TITLE
[iOS] ✨ Index KMP files to enable Xcode autocomplete/hinting

### DIFF
--- a/ios/MateeStarter.xcodeproj/xcshareddata/xcschemes/MateeStarter.xcscheme
+++ b/ios/MateeStarter.xcodeproj/xcshareddata/xcschemes/MateeStarter.xcscheme
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Embed and sign shared framework"
-               scriptText = "cd &quot;$SRCROOT/..&quot;&#10;./gradlew :shared:core:embedAndSignAppleFrameworkForXcode &lt; /dev/null&#10;&#10;DERIVED_DATA_DIR=$(echo &quot;${TARGET_BUILD_DIR}&quot; | awk -F&apos;/Build/&apos; &apos;{print $1}&apos;)&#10;INDEXER_DATA_DIR=${DERIVED_DATA_DIR}/Index.noindex/Build/Products/Debug-$PLATFORM_NAME&#10;mkdir -p $INDEXER_DATA_DIR&#10;cp -R &quot;shared/core/build/xcode-frameworks/$CONFIGURATION/$SDK_NAME/&quot;* &quot;${INDEXER_DATA_DIR}&quot;&#10;">
+               scriptText = "cd &quot;$SRCROOT/..&quot;&#10;ios/scripts/build-kmp.sh&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/MateeStarter.xcodeproj/xcshareddata/xcschemes/MateeStarter_Alpha.xcscheme
+++ b/ios/MateeStarter.xcodeproj/xcshareddata/xcschemes/MateeStarter_Alpha.xcscheme
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Embed and sign shared framework"
-               scriptText = "cd &quot;$SRCROOT/..&quot;&#10;./gradlew :shared:core:embedAndSignAppleFrameworkForXcode &lt; /dev/null&#10;&#10;DERIVED_DATA_DIR=$(echo &quot;${TARGET_BUILD_DIR}&quot; | awk -F&apos;/Build/&apos; &apos;{print $1}&apos;)&#10;INDEXER_DATA_DIR=${DERIVED_DATA_DIR}/Index.noindex/Build/Products/Debug-$PLATFORM_NAME&#10;mkdir -p $INDEXER_DATA_DIR&#10;cp -R &quot;shared/core/build/xcode-frameworks/$CONFIGURATION/$SDK_NAME/&quot;* &quot;${INDEXER_DATA_DIR}&quot;&#10;">
+               scriptText = "cd &quot;$SRCROOT/..&quot;&#10;ios/scripts/build-kmp.sh&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/scripts/build-kmp.sh
+++ b/ios/scripts/build-kmp.sh
@@ -1,0 +1,7 @@
+./gradlew :shared:core:embedAndSignAppleFrameworkForXcode < /dev/null
+
+# Copy the framework to indexer directory to support Xcode hinting/autocomplete
+DERIVED_DATA_DIR="$(echo "${TARGET_BUILD_DIR}" | awk -F'/Build/' '{print $1}')"
+INDEXER_DATA_DIR="${DERIVED_DATA_DIR}/Index.noindex/Build/Products/Debug-${PLATFORM_NAME}"
+mkdir -p "$INDEXER_DATA_DIR"
+cp -R "shared/core/build/xcode-frameworks/$CONFIGURATION/$SDK_NAME/"* "${INDEXER_DATA_DIR}"


### PR DESCRIPTION
# :pencil: Description
- This PR enables Xcode autocomplete/hinting for KMP code

# :bulb: What’s new?
- Manual copy of the KMP framework after the `embedAndSign` task into the index path

# :books: References
- https://slack-chats.kotlinlang.org/t/16647904/hello-we-re-facing-an-issue-where-code-completion-and-symbol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Improved iOS development/build workflow to automate framework provisioning and ensure Xcode can index and hint/autocomplete correctly, reducing IDE-related issues and smoothing local development.
  - No changes to app functionality or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->