### PR TITLE
♻️ [KMP] Refactor and simplify refresh token login in AuthProviderImpl

### DIFF
--- a/shared/auth/src/commonMain/kotlin/kmp/shared/auth/data/provider/AuthProviderImpl.kt
+++ b/shared/auth/src/commonMain/kotlin/kmp/shared/auth/data/provider/AuthProviderImpl.kt
@@ -4,11 +4,10 @@ import com.russhwolf.settings.Settings
 import com.russhwolf.settings.set
 import kmp.shared.auth.data.remote.TokenRefresher
 import kmp.shared.base.data.provider.AuthProvider
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 
 internal class AuthProviderImpl(
     private val settings: Settings,
@@ -20,29 +19,17 @@ internal class AuthProviderImpl(
         set(value) = settings.set(TOKEN_KEY, value)
 
     private val mutex = Mutex()
-    private var inFlight: Deferred<String?>? = null
 
-    override suspend fun refreshToken(): String? = coroutineScope {
+    override suspend fun refreshToken(): String? {
+        val oldToken = token
+
         mutex.withLock {
-            inFlight?.let { return@coroutineScope it.await() }
-
-            val task = async {
-                val fresh = tokenRefresher.refresh()
-                token = fresh
-                fresh
-            }
-            inFlight = task
-            task
-        }.let { task ->
-            try {
-                task.await()
-            } finally {
-                mutex.withLock {
-                    if (inFlight === task) {
-                        inFlight = null
-                    }
+            if (oldToken == token) {
+                withContext(NonCancellable) {
+                    token = tokenRefresher.refresh()
                 }
             }
+            return token
         }
     }
 


### PR DESCRIPTION
# :pencil: Description
- Logic for refreshing token was over-complicated and dependent on coroutine scope of the first caller

# :bulb: What’s new?
- With @filwiesner we refactored and simplified the AuthProviderImpl and fixed the problem with the scope that is refreshing being cancelled in which case subsequent calls would not get the refreshed token

# :no_mouth: What’s missing?
- Nothing



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified and hardened token refresh logic to ensure refreshes run sequentially and avoid overlapping attempts; no public API changes.
* **Bug Fixes**
  * Reduces rare authentication errors and unexpected sign-outs during concurrent requests, improving session stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->