### PR TITLE
🐛 Bump max memory limit for JVM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # KOTLIN
 kotlin.code.style=official
 # JVM
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8192M -Dkotlin.daemon.jvm.options\="-Xmx8192M" -Dfile.encoding\=UTF-8
 # ANDROID
 android.useAndroidX=true
 # MP


### PR DESCRIPTION
- Some new projects ran into a problem with the JVM's maximum memory limit, so I just adjusted it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system configuration by increasing Java Virtual Machine memory allocation, allowing more resources for compilation tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->