### PR TITLE
🐛 Fix inverted sendWithoutRequest predicate in HttpClient

### DIFF
--- a/shared/base/src/commonMain/kotlin/kmp/shared/base/data/remote/HttpClient.kt
+++ b/shared/base/src/commonMain/kotlin/kmp/shared/base/data/remote/HttpClient.kt
@@ -65,7 +65,7 @@ internal object HttpClient {
                     }
 
                     sendWithoutRequest { request ->
-                        unauthorizedEndpoints.any(request.url.encodedPath::equals)
+                        unauthorizedEndpoints.none(request.url.encodedPath::equals)
                     }
                 }
             }


### PR DESCRIPTION
`sendWithoutRequest` in Ktor returns `true` to attach the bearer token preemptively — the canonical example from the [docs](https://ktor.io/docs/client-bearer-auth.html) is `request.url.host == "www.googleapis.com"`, i.e. return `true` for hosts where you _want_ the token.

The block in `HttpClient.kt` returned `true` for `unauthorizedEndpoints`, which inverts the intent:

- the bearer token was being sent to `/api/auth/login` and `/api/auth/registration`
- every authenticated request wasn't sent preemptively — it had to bounce off a 401 first, then retry

Flipped `.any` → `.none` so the token is attached to authenticated endpoints and skipped for the auth ones, matching the variable name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bearer authentication behavior for login and registration endpoints. These critical authentication flows now properly manage token requirements, ensuring users can seamlessly complete initial authentication without encountering unnecessary token validation blocks. This enhances the overall experience for both new and returning users accessing the platform.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MateeDevs/MateeStarter/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->